### PR TITLE
Enable AC for 2.0 knob setting

### DIFF
--- a/e-vent.ino
+++ b/e-vent.ino
@@ -256,7 +256,7 @@ void loop() {
 
       // Check if patient triggers inhale
       patientTriggered = pressureReader.get() < (pressureReader.peep() - knobs.ac()) 
-          && knobs.ac() > AC_MIN;
+          && (knobs.ac() > AC_MIN - 1e-2f);
 
       if (patientTriggered || now() - tCycleTimer > tPeriod) {
         if (!patientTriggered) pressureReader.set_peep();  // Set peep again if time triggered

--- a/e-vent.ino
+++ b/e-vent.ino
@@ -256,7 +256,7 @@ void loop() {
 
       // Check if patient triggers inhale
       patientTriggered = pressureReader.get() < (pressureReader.peep() - knobs.ac()) 
-          && (knobs.ac() > AC_MIN - 1e-2f);
+          && (knobs.ac() > AC_MIN - 1e-2);
 
       if (patientTriggered || now() - tCycleTimer > tPeriod) {
         if (!patientTriggered) pressureReader.set_peep();  // Set peep again if time triggered


### PR DESCRIPTION
Ensure that the AC knob setting of 2.0 is actually ON using the same condition in Display:

https://github.com/mit-drl/e-vent/blob/b1de3cd19d1eec190a23042a18fc2e8ed5efcdb9/Display.cpp#L182

Ultimately, this condition needs to be checked once and used when needed by the display or the main code flow logic by utilizing the assist control flag. Leaving the use of such a flag for a further refactoring commit.

This has been tested on the device.