### PR TITLE
Fix/typo

### DIFF
--- a/Display.h
+++ b/Display.h
@@ -202,7 +202,7 @@ private:
   template void Display::write(const DisplayKey& key, const type& value);
 INSTANTIATE_WRITE(int)
 INSTANTIATE_WRITE(float)
-#undef INSTANTIATE
+#undef INSTANTIATE_WRITE
 
 
 }  // namespace display


### PR DESCRIPTION
Fixes a small typo in undefining INSTANTIATE_WRITE. Purely for correctness, no changes in behavior expected.

Tested on hardware.